### PR TITLE
Replace Ctx.CustomObjects type with thread safe and secure ObjectMap API

### DIFF
--- a/context.go
+++ b/context.go
@@ -7,7 +7,7 @@ type Ctx struct {
 	Session       *discordgo.Session
 	Event         *discordgo.MessageCreate
 	Arguments     *Arguments
-	CustomObjects map[string]interface{}
+	CustomObjects *ObjectsMap
 	Router        *Router
 	Command       *Command
 }

--- a/examples/test.go
+++ b/examples/test.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/Lukaesebrot/dgc"
+	"github.com/bwmarrin/discordgo"
+)
+
+func main() {
+	// Open a simple Discord session
+	token := os.Getenv("TOKEN")
+	session, err := discordgo.New("Bot " + token)
+	if err != nil {
+		panic(err)
+	}
+	err = session.Open()
+	if err != nil {
+		panic(err)
+	}
+
+	defer func() {
+		sc := make(chan os.Signal, 1)
+		signal.Notify(sc, syscall.SIGINT, syscall.SIGTERM, os.Interrupt, os.Kill)
+		<-sc
+	}()
+
+	// Create a dgc router
+	// NOTE: The dgc.Create function makes sure all internal and external maps of the struct get initialized, so you should use it in every case!
+	router := dgc.Create(&dgc.Router{
+		// We will allow '!', '$' and the bot mention as command prefixes
+		// NOTE: The first prefix (in our case '!') will be used as the prefix in the default help messages
+		Prefixes: []string{
+			"!",
+			"$",
+			"<@!" + session.State.User.ID + ">",
+		},
+
+		// Whether or not the parser should ignore the case of our prefixes (this would be redundant in our case)
+		IgnorePrefixCase: false,
+
+		// Whether or not bots should be allowed to execute our commands
+		BotsAllowed: false,
+
+		// We can define commands in here, but in this example we will use the provided method (later)
+		Commands: []*dgc.Command{
+			// ...
+		},
+
+		// We can define middlewares in here, but in this example we will use the provided method (later)
+		Middlewares: map[string][]dgc.Middleware{
+			// ...
+		},
+
+		// The ping handler will be executed if the message only contains the bot's mention (no arguments)
+		PingHandler: func(ctx *dgc.Ctx) {
+			_, err := ctx.Session.ChannelMessageSend(ctx.Event.ChannelID, "Pong!")
+			if err != nil {
+				// Error handling
+			}
+		},
+	})
+
+	// Add a simple command
+	router.RegisterCmd(&dgc.Command{
+		// The general name of the command
+		Name: "hey",
+
+		// The aliases of the command
+		Aliases: []string{
+			"hi",
+			"hello",
+		},
+
+		// A brief description of the commands functionality
+		Description: "Greets you",
+
+		// The correct usage of the command
+		Usage: "hey",
+
+		// An example how to use the command
+		Example: "hey",
+
+		// Commands may have flags. They will be used for middleware selection and can also be used for grouping
+		Flags: []string{
+			"greeting",
+		},
+
+		// Whether or not the parser should ignore the case of our command
+		IgnoreCase: true,
+
+		// A list of sub commands
+		SubCommands: []*dgc.Command{
+			{
+				Name:        "world",
+				Description: "Greets the world",
+				Usage:       "hey world",
+				Example:     "greet world",
+				Flags: []string{
+					"greeting",
+				},
+				IgnoreCase: true,
+				Handler: func(ctx *dgc.Ctx) {
+					_, err := ctx.Session.ChannelMessageSend(ctx.Event.ChannelID, "Hello, world.")
+					if err != nil {
+						// Error handling
+					}
+				},
+			},
+		},
+
+		// dgc supports rate limiting. You can define a rate limiter here.
+		RateLimiter: dgc.NewRateLimiter(5*time.Second, 2*time.Second, func(ctx *dgc.Ctx) {
+			_, err := ctx.Session.ChannelMessageSend(ctx.Event.ChannelID, "You are being rate limited!")
+			if err != nil {
+				// Error handling
+			}
+
+			// HINT: You can get the timestamp when the next execution is allowed like this:
+			// nextExecution := ctx.CustomObjects.MustGet("dgc_nextExecution").(time.Time)
+		}),
+
+		// The handler of the command
+		Handler: func(ctx *dgc.Ctx) {
+			_, err := ctx.Session.ChannelMessageSend(ctx.Event.ChannelID, "Hello.")
+			if err != nil {
+				// Error handling
+			}
+		},
+	})
+
+	// Add a simple middleware that injects a custom object into the context
+	// This middleware will be executed on every command, because we wildcard it using the '*'
+	// NOTE: You have to return true or false. If you return false, the command will not be executed
+	router.AddMiddleware("*", func(ctx *dgc.Ctx) bool {
+		// Inject a custom object into the context
+		ctx.CustomObjects.Set("myObjectName", "Hello, world")
+		return true
+	})
+
+	// This middleware will only be executed for commands that implement the 'greeting' flag
+	router.AddMiddleware("greeting", func(ctx *dgc.Ctx) bool {
+		// Inject a custom object into the context
+		ctx.CustomObjects.Set("foo", "bar")
+		return true
+	})
+
+	// Enable the default help command
+	router.RegisterDefaultHelpCommand(session, nil)
+
+	// Initialize the router to make it functional
+	router.Initialize(session)
+}

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.14
 
 require (
 	github.com/bwmarrin/discordgo v0.20.3
-	github.com/zekroTJA/timedmap v0.0.0-20200421070859-4302645f33f5
+	github.com/zekroTJA/timedmap v0.0.0-20200518230343-de9b879d109a
 )

--- a/go.sum
+++ b/go.sum
@@ -4,5 +4,7 @@ github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/zekroTJA/timedmap v0.0.0-20200421070859-4302645f33f5 h1:LoUppaRvaFRGh8/hF7848Hl5g9FcddkP8cVPJJ0y0fQ=
 github.com/zekroTJA/timedmap v0.0.0-20200421070859-4302645f33f5/go.mod h1:ktlw5aYhoXQvOvWFL9SzltGXn1bQgJXxZzHJK4wQvsI=
+github.com/zekroTJA/timedmap v0.0.0-20200518230343-de9b879d109a h1:S8UfZYz3TbkwO8bZ1UE3miiEjh/KSi4tZYwX1A/omC4=
+github.com/zekroTJA/timedmap v0.0.0-20200518230343-de9b879d109a/go.mod h1:ktlw5aYhoXQvOvWFL9SzltGXn1bQgJXxZzHJK4wQvsI=
 golang.org/x/crypto v0.0.0-20181030102418-4d3f4d9ffa16 h1:y6ce7gCWtnH+m3dCjzQ1PCuwl28DDIc3VNnvY29DlIA=
 golang.org/x/crypto v0.0.0-20181030102418-4d3f4d9ffa16/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/helpCommand.go
+++ b/helpCommand.go
@@ -110,7 +110,7 @@ func renderDefaultSpecificHelpEmbed(ctx *Ctx, command *Command) *discordgo.Messa
 			Timestamp: time.Now().Format(time.RFC3339),
 			Color:     0xff0000,
 			Fields: []*discordgo.MessageEmbedField{
-				&discordgo.MessageEmbedField{
+				{
 					Name:   "Message",
 					Value:  "```The given command doesn't exist. Type `" + prefix + "help` for a list of available commands.```",
 					Inline: false,
@@ -143,32 +143,32 @@ func renderDefaultSpecificHelpEmbed(ctx *Ctx, command *Command) *discordgo.Messa
 		Timestamp:   time.Now().Format(time.RFC3339),
 		Color:       0xffff00,
 		Fields: []*discordgo.MessageEmbedField{
-			&discordgo.MessageEmbedField{
+			{
 				Name:   "Name",
 				Value:  "`" + command.Name + "`",
 				Inline: false,
 			},
-			&discordgo.MessageEmbedField{
+			{
 				Name:   "Sub Commands",
 				Value:  subCommands,
 				Inline: false,
 			},
-			&discordgo.MessageEmbedField{
+			{
 				Name:   "Aliases",
 				Value:  aliases,
 				Inline: false,
 			},
-			&discordgo.MessageEmbedField{
+			{
 				Name:   "Description",
 				Value:  "```" + command.Description + "```",
 				Inline: false,
 			},
-			&discordgo.MessageEmbedField{
+			{
 				Name:   "Usage",
 				Value:  "```" + prefix + command.Usage + "```",
 				Inline: false,
 			},
-			&discordgo.MessageEmbedField{
+			{
 				Name:   "Example",
 				Value:  "```" + prefix + command.Example + "```",
 				Inline: false,

--- a/objectsMap.go
+++ b/objectsMap.go
@@ -1,0 +1,48 @@
+package dgc
+
+import "sync"
+
+// ObjectsMap wraps a map[string]interface
+// to provide thread safe access endpoints.
+type ObjectsMap struct {
+	mtx sync.RWMutex
+	m   map[string]interface{}
+}
+
+// newObjectsMap initializes a new
+// ObjectsMap instance
+func newObjectsMap() *ObjectsMap {
+	return &ObjectsMap{
+		m: make(map[string]interface{}),
+	}
+}
+
+// Get tries to get a value from the map.
+// If a value was found, the value and true
+// is returned. Else, nil and false is
+// returned.
+func (om *ObjectsMap) Get(key string) (interface{}, bool) {
+	om.mtx.RLock()
+	defer om.mtx.RUnlock()
+
+	v, ok := om.m[key]
+	return v, ok
+}
+
+// MustGet wraps Get but only returns the
+// value, if found, or nil otherwise.
+func (om *ObjectsMap) MustGet(key string) interface{} {
+	v, ok := om.Get(key)
+	if !ok {
+		return nil
+	}
+	return v
+}
+
+// Set sets a value to the map by key.
+func (om *ObjectsMap) Set(key string, val interface{}) {
+	om.mtx.Lock()
+	defer om.mtx.Unlock()
+
+	om.m[key] = val
+}

--- a/objectsMap.go
+++ b/objectsMap.go
@@ -46,3 +46,11 @@ func (om *ObjectsMap) Set(key string, val interface{}) {
 
 	om.m[key] = val
 }
+
+// Delete removes a key-value pair from the map.
+func (om *ObjectsMap) Delete(key string) {
+	om.mtx.Lock()
+	defer om.mtx.Unlock()
+
+	delete(om.m, key)
+}

--- a/objectsMap.go
+++ b/objectsMap.go
@@ -5,15 +5,15 @@ import "sync"
 // ObjectsMap wraps a map[string]interface
 // to provide thread safe access endpoints.
 type ObjectsMap struct {
-	mtx sync.RWMutex
-	m   map[string]interface{}
+	mutex    sync.RWMutex
+	innerMap map[string]interface{}
 }
 
 // newObjectsMap initializes a new
 // ObjectsMap instance
 func newObjectsMap() *ObjectsMap {
 	return &ObjectsMap{
-		m: make(map[string]interface{}),
+		innerMap: make(map[string]interface{}),
 	}
 }
 
@@ -22,10 +22,10 @@ func newObjectsMap() *ObjectsMap {
 // is returned. Else, nil and false is
 // returned.
 func (om *ObjectsMap) Get(key string) (interface{}, bool) {
-	om.mtx.RLock()
-	defer om.mtx.RUnlock()
+	om.mutex.RLock()
+	defer om.mutex.RUnlock()
 
-	v, ok := om.m[key]
+	v, ok := om.innerMap[key]
 	return v, ok
 }
 
@@ -41,16 +41,16 @@ func (om *ObjectsMap) MustGet(key string) interface{} {
 
 // Set sets a value to the map by key.
 func (om *ObjectsMap) Set(key string, val interface{}) {
-	om.mtx.Lock()
-	defer om.mtx.Unlock()
+	om.mutex.Lock()
+	defer om.mutex.Unlock()
 
-	om.m[key] = val
+	om.innerMap[key] = val
 }
 
 // Delete removes a key-value pair from the map.
 func (om *ObjectsMap) Delete(key string) {
-	om.mtx.Lock()
-	defer om.mtx.Unlock()
+	om.mutex.Lock()
+	defer om.mutex.Unlock()
 
-	delete(om.m, key)
+	delete(om.innerMap, key)
 }

--- a/rateLimiter.go
+++ b/rateLimiter.go
@@ -28,7 +28,7 @@ func (rateLimiter *RateLimiter) NotifyExecution(ctx *Ctx) bool {
 		if rateLimiter.RateLimitedHandler != nil {
 			nextExecution, err := rateLimiter.executions.GetExpires(ctx.Event.Author.ID)
 			if err != nil {
-				ctx.CustomObjects["dgc_nextExecution"] = nextExecution
+				ctx.CustomObjects.Set("dgc_nextExecution", nextExecution)
 			}
 			rateLimiter.RateLimitedHandler(ctx)
 		}

--- a/router.go
+++ b/router.go
@@ -177,7 +177,7 @@ func (router *Router) handler() func(*discordgo.Session, *discordgo.MessageCreat
 					Session:       session,
 					Event:         event,
 					Arguments:     ParseArguments(content),
-					CustomObjects: make(map[string]interface{}),
+					CustomObjects: newObjectsMap(),
 					Router:        router,
 					Command:       command,
 				}


### PR DESCRIPTION
Hey! 👋

I stumbled across this project a while ago and currently, I'm thinking about using it in the upstanding rework of yuri, so I've decided to try to give some improvements to this package, if wanted. ^^

First of all, using a raw `map[string]interface{}` as `Ctx.CustomObjects` might bring some nasty issues. Concurrently reading on maps in go is fine until you read/write on maps in parallel, which will lead to a panic.
Here you can read more about this with some handy examples:
https://qvault.io/2020/03/19/golang-mutexes-what-is-rwmutex-for

So i've simply wrapped the map with a `sync.RWMutex` which blocks access to the map while writing to it and also providing some nice API endpoints for accessing the CustomObjects field.

Also, I've simplified the inline object creation in the embed arrays of `helpCommand.go`.

Additionally, I've put the example from the README into the example directory so that people can test around with the package using the provided example.
